### PR TITLE
Inline comment correction

### DIFF
--- a/pyarrow_ops/helpers.py
+++ b/pyarrow_ops/helpers.py
@@ -4,8 +4,8 @@ def groupify_array(arr):
     # Input: Pyarrow/Numpy array
     # Output:
     #   - 1. Unique values
-    #   - 2. Sort index
-    #   - 3. Count per unique
+    #   - 2. Count per unique
+    #   - 3. Sort index
     #   - 4. Begin index per unique
     dic, counts = np.unique(arr, return_counts=True)
     sort_idx = np.argsort(arr)


### PR DESCRIPTION
I've been looking at how you've implemented the GroupBy functionality and noted what I think is a discrepancy in the inline comments in the `groupify_array` method in the helpers module.

This is the code:

~~~python
def groupify_array(arr):
    # Input: Pyarrow/Numpy array
    # Output:
    #   - 1. Unique values
    #   - 2. Sort index
    #   - 3. Count per unique
    #   - 4. Begin index per unique
    dic, counts = np.unique(arr, return_counts=True)
    sort_idx = np.argsort(arr)
    return dic, counts, sort_idx, [0] + np.cumsum(counts)[:-1].tolist()
~~~

Note the output lists the "Sort index" as the second returned item, but it's the third in the return line.

Checking to ensure the method using this call isn't compensating but applying the "correct" names to the returned values by looking at the grouping module, it's reading the variables and applying the same names:

~~~python
self.dic, self.counts, self.sort_idxs, self.bgn_idxs = groupify_array(self.arr)
~~~

and then when using these values, it appears to use them as per the variable names:

~~~python
idxs = self.sort_idxs[self.bgn_idxs[i] : self.bgn_idxs[i] + self.counts[i]]
~~~

I've concluded it's the comments that are incorrect and corrected in this PR.